### PR TITLE
feat(judges): página de detalle enriquecida y migración a URLs por slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Observatorio Judicial Argentino — Frontend
 
-[![CI](https://github.com/tu-org/observatorio-judicial-argentino/actions/workflows/ci.yml/badge.svg)](https://github.com/tu-org/observatorio-judicial-argentino/actions/workflows/ci.yml)
+[![CI](https://github.com/observatorio-justicia-argentina/observatorio-justicia-argentina-frontend/actions/workflows/ci.yml/badge.svg)](https://github.com/observatorio-justicia-argentina/observatorio-justicia-argentina-frontend/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 
@@ -35,7 +35,7 @@ El sistema **no tiene fines punitivos ni políticos**. Es estadístico, trazable
 ## Requisitos previos
 
 - Node.js ≥ 20
-- Backend corriendo en `http://localhost:3600` ([ver repo backend](../observatorio-backend/README.md))
+- Backend corriendo en `http://localhost:3600` ([ver repo backend](https://github.com/observatorio-justicia-argentina/observatorio-justicia-argentina-backend))
 
 ---
 
@@ -43,8 +43,8 @@ El sistema **no tiene fines punitivos ni políticos**. Es estadístico, trazable
 
 ```bash
 # 1. Clonar
-git clone https://github.com/tu-org/observatorio-judicial-argentino.git
-cd observatorio-judicial-argentino
+git clone https://github.com/observatorio-justicia-argentina/observatorio-justicia-argentina-frontend.git
+cd observatorio-justicia-argentina-frontend
 
 # 2. Instalar dependencias (también instala los hooks de Husky)
 npm install

--- a/app/components/JudgeFilters.tsx
+++ b/app/components/JudgeFilters.tsx
@@ -122,9 +122,9 @@ export function applyFilters(judges: Judge[], filters: FilterState): Judge[] {
 }
 
 export default function JudgeFilters({ filters, onChange, judges }: Props) {
-  const fueros = [...new Set(judges.map((j) => j.jurisdiction.fuero))];
-  const instances = [...new Set(judges.map((j) => j.jurisdiction.instance))];
-  const scopes = [...new Set(judges.map((j) => j.jurisdiction.scope))];
+  const fueros = [...new Set(judges.map((j) => j.jurisdiction?.fuero).filter(Boolean))];
+  const instances = [...new Set(judges.map((j) => j.jurisdiction?.instance).filter(Boolean))];
+  const scopes = [...new Set(judges.map((j) => j.jurisdiction?.scope).filter(Boolean))];
 
   const hasActiveFilters =
     filters.activeFuero ||

--- a/app/juez/[id]/page.tsx
+++ b/app/juez/[id]/page.tsx
@@ -1,0 +1,487 @@
+"use client";
+
+import Link from "next/link";
+import { use, useEffect, useState } from "react";
+import {
+  ArchivoPublico,
+  Caso,
+  fetchJudgeArchivos,
+  fetchJudgeCases,
+  fetchJudges,
+  Judge,
+  ResultadoCaso,
+} from "../../lib/api";
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+// Se usa como fallback hasta que el backend implemente GET /api/judges/:id/casos
+// y GET /api/judges/:id/archivos. Remover cuando estén disponibles.
+
+const MOCK_CASOS: Caso[] = [
+  {
+    id: "mock-1",
+    nroExpediente: "12345/2024",
+    fechaResolucion: "2024-03-15",
+    tipoMedida: "Libertad cautelar",
+    resultado: "fta",
+    observaciones: "El imputado no se presentó a la audiencia fijada para el 20/04/2024.",
+  },
+  {
+    id: "mock-2",
+    nroExpediente: "98732/2024",
+    fechaResolucion: "2024-06-02",
+    tipoMedida: "Excarcelación",
+    resultado: "nuevo_arresto",
+    observaciones: "Detenido nuevamente el 14/07/2024 por robo agravado.",
+  },
+  {
+    id: "mock-3",
+    nroExpediente: "45210/2023",
+    fechaResolucion: "2023-11-20",
+    tipoMedida: "Prisión preventiva atenuada",
+    resultado: "revocada",
+    observaciones: "La Cámara revocó la medida por incumplimiento de condiciones.",
+  },
+  {
+    id: "mock-4",
+    nroExpediente: "67891/2025",
+    fechaResolucion: "2025-01-10",
+    tipoMedida: "Libertad cautelar",
+    resultado: "pendiente",
+  },
+];
+
+const MOCK_ARCHIVOS: ArchivoPublico[] = [
+  {
+    id: "arch-1",
+    nombre: "Resolución 12345-2024.pdf",
+    url: "#",
+    fechaCarga: "2024-04-01",
+  },
+  {
+    id: "arch-2",
+    nombre: "Acta audiencia 98732-2024.pdf",
+    url: "#",
+    fechaCarga: "2024-07-20",
+  },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const RESULTADO_LABEL: Record<ResultadoCaso, string> = {
+  fta: "No compareció",
+  nuevo_arresto: "Nuevo arresto",
+  revocada: "Revocada",
+  pendiente: "Pendiente",
+};
+
+const RESULTADO_COLOR: Record<ResultadoCaso, { bg: string; text: string; border: string }> = {
+  fta: { bg: "#d2992220", text: "#d29922", border: "#d2992240" },
+  nuevo_arresto: { bg: "#f8514920", text: "#f85149", border: "#f8514940" },
+  revocada: { bg: "#a371f720", text: "#a371f7", border: "#a371f740" },
+  pendiente: { bg: "#74ACDF20", text: "#74ACDF", border: "#74ACDF40" },
+};
+
+function ResultadoBadge({ resultado }: { resultado: ResultadoCaso }) {
+  const c = RESULTADO_COLOR[resultado];
+  return (
+    <span
+      className="rounded-full px-2.5 py-0.5 text-xs font-medium"
+      style={{ backgroundColor: c.bg, color: c.text, border: `1px solid ${c.border}` }}
+    >
+      {RESULTADO_LABEL[resultado]}
+    </span>
+  );
+}
+
+function StatBox({ value, label, color }: { value: number; label: string; color: string }) {
+  return (
+    <div
+      className="flex flex-col items-center rounded-lg px-4 py-3"
+      style={{ backgroundColor: "#0d1117" }}
+    >
+      <span className="text-2xl font-bold" style={{ color }}>
+        {value}
+      </span>
+      <span className="mt-0.5 text-center text-xs" style={{ color: "#7d8590" }}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+// ── Componente principal ──────────────────────────────────────────────────────
+
+export default function JudgeDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const judgeId = Number(id);
+
+  const [judge, setJudge] = useState<Judge | null>(null);
+  const [casos, setCasos] = useState<Caso[]>([]);
+  const [archivos, setArchivos] = useState<ArchivoPublico[]>([]);
+  const [loadingJudge, setLoadingJudge] = useState(true);
+  const [loadingCasos, setLoadingCasos] = useState(true);
+  const [errorJudge, setErrorJudge] = useState<string | null>(null);
+  const [usingMockData, setUsingMockData] = useState(false);
+
+  // Cargar datos del juez desde la lista existente
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const judges = await fetchJudges();
+        if (!cancelled) {
+          const found = judges.find((j) => j.id === judgeId) ?? null;
+          setJudge(found);
+          if (!found) setErrorJudge("Juez no encontrado.");
+        }
+      } catch {
+        if (!cancelled) setErrorJudge("No se pudo conectar con el backend.");
+      } finally {
+        if (!cancelled) setLoadingJudge(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [judgeId]);
+
+  // Cargar casos e archivos — con fallback a mock data
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoadingCasos(true);
+      try {
+        const [casosData, archivosData] = await Promise.all([
+          fetchJudgeCases(judgeId),
+          fetchJudgeArchivos(judgeId),
+        ]);
+        if (!cancelled) {
+          setCasos(casosData);
+          setArchivos(archivosData);
+        }
+      } catch {
+        // El endpoint aún no existe en el backend — usar datos de ejemplo
+        if (!cancelled) {
+          setCasos(MOCK_CASOS);
+          setArchivos(MOCK_ARCHIVOS);
+          setUsingMockData(true);
+        }
+      } finally {
+        if (!cancelled) setLoadingCasos(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [judgeId]);
+
+  const failureRate =
+    judge && judge.totalReleases > 0
+      ? (
+          ((judge.ftaCount + judge.newArrestCount + judge.revokedCount) / judge.totalReleases) *
+          100
+        ).toFixed(1)
+      : "0.0";
+  const rate = parseFloat(failureRate);
+  const rateColor = rate > 20 ? "#f85149" : rate > 10 ? "#F4B942" : "#3fb950";
+  const rateBg = rate > 20 ? "#f8514920" : rate > 10 ? "#F4B94220" : "#3fb95020";
+
+  const locationPath =
+    judge &&
+    (judge.location.department.toLowerCase().includes(judge.location.province.toLowerCase())
+      ? judge.location.department
+      : `${judge.location.province} › ${judge.location.department}`);
+
+  return (
+    <main className="mx-auto w-full max-w-5xl px-4 py-10 sm:px-6 lg:px-8">
+      {/* Breadcrumb */}
+      <Link
+        href="/"
+        className="mb-6 inline-flex items-center gap-1.5 text-sm transition-colors hover:text-[#e6edf3]"
+        style={{ color: "#74ACDF" }}
+      >
+        <svg
+          className="h-4 w-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+        Volver al dashboard
+      </Link>
+
+      {/* Error state */}
+      {errorJudge && !loadingJudge && (
+        <div
+          className="rounded-lg border px-4 py-3 text-sm"
+          style={{ backgroundColor: "#f8514910", borderColor: "#f85149", color: "#f85149" }}
+        >
+          {errorJudge}
+        </div>
+      )}
+
+      {/* Loading skeleton */}
+      {loadingJudge && (
+        <div className="space-y-4">
+          <div
+            className="h-40 animate-pulse rounded-xl border"
+            style={{ backgroundColor: "#161b22", borderColor: "#21262d" }}
+          />
+          <div
+            className="h-64 animate-pulse rounded-xl border"
+            style={{ backgroundColor: "#161b22", borderColor: "#21262d" }}
+          />
+        </div>
+      )}
+
+      {/* Judge header */}
+      {!loadingJudge && judge && (
+        <>
+          <article
+            className="rounded-xl border overflow-hidden mb-6"
+            style={{ backgroundColor: "#161b22", borderColor: "#21262d" }}
+          >
+            {/* Header */}
+            <div
+              className="flex flex-wrap items-start justify-between gap-3 px-6 py-5"
+              style={{ borderBottom: "1px solid #21262d" }}
+            >
+              <div className="min-w-0">
+                <h1 className="text-xl font-bold" style={{ color: "#e6edf3" }}>
+                  {judge.name}
+                </h1>
+                <p className="mt-1 text-sm" style={{ color: "#74ACDF" }}>
+                  {judge.court}
+                </p>
+                <p className="mt-0.5 text-xs" style={{ color: "#7d8590" }}>
+                  {locationPath}
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <span
+                  className="rounded-full px-2.5 py-0.5 text-xs font-medium"
+                  style={{
+                    backgroundColor: "#74ACDF15",
+                    color: "#74ACDF",
+                    border: "1px solid #74ACDF30",
+                  }}
+                >
+                  {judge.location.province}
+                </span>
+                <span
+                  className="rounded-full px-3 py-0.5 text-sm font-bold"
+                  style={{
+                    backgroundColor: rateBg,
+                    color: rateColor,
+                    border: `1px solid ${rateColor}40`,
+                  }}
+                >
+                  {failureRate}% falla procesal
+                </span>
+              </div>
+            </div>
+
+            {/* Stats */}
+            <div className="grid grid-cols-2 gap-3 p-5 sm:grid-cols-4">
+              <StatBox value={judge.totalReleases} label="Libertades otorgadas" color="#e6edf3" />
+              <StatBox value={judge.ftaCount} label="No compareció" color="#d29922" />
+              <StatBox value={judge.newArrestCount} label="Nuevo arresto" color="#f85149" />
+              <StatBox value={judge.revokedCount} label="Medida revocada" color="#a371f7" />
+            </div>
+          </article>
+
+          {/* Mock data notice */}
+          {usingMockData && (
+            <div
+              className="mb-5 flex items-start gap-3 rounded-lg border px-4 py-3 text-sm"
+              style={{
+                backgroundColor: "#d2992210",
+                borderColor: "#d2992240",
+                color: "#d29922",
+              }}
+            >
+              <svg
+                className="mt-0.5 h-4 w-4 shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+                />
+              </svg>
+              <span>
+                <strong>Vista previa con datos de ejemplo.</strong> El endpoint{" "}
+                <code className="rounded px-1 text-xs" style={{ backgroundColor: "#21262d" }}>
+                  GET /api/judges/:id/casos
+                </code>{" "}
+                aún no está implementado en el backend. Los casos mostrados son ficticios.
+              </span>
+            </div>
+          )}
+
+          {/* Cases section */}
+          <section>
+            <div className="mb-4 flex items-center gap-2">
+              <h2 className="text-base font-bold" style={{ color: "#e6edf3" }}>
+                Casos registrados
+              </h2>
+              {!loadingCasos && (
+                <span
+                  className="rounded-full px-2 py-0.5 text-xs font-semibold"
+                  style={{ backgroundColor: "#21262d", color: "#7d8590" }}
+                >
+                  {casos.length}
+                </span>
+              )}
+            </div>
+
+            {loadingCasos ? (
+              <div
+                className="h-40 animate-pulse rounded-xl border"
+                style={{ backgroundColor: "#161b22", borderColor: "#21262d" }}
+              />
+            ) : casos.length === 0 ? (
+              <div
+                className="flex flex-col items-center justify-center rounded-xl border py-12"
+                style={{ borderColor: "#21262d", backgroundColor: "#161b22" }}
+              >
+                <p className="font-medium" style={{ color: "#e6edf3" }}>
+                  Sin casos registrados
+                </p>
+                <p className="mt-1 text-sm" style={{ color: "#7d8590" }}>
+                  Aún no se han cargado expedientes para este juez.
+                </p>
+              </div>
+            ) : (
+              <div className="overflow-hidden rounded-xl border" style={{ borderColor: "#21262d" }}>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr style={{ backgroundColor: "#161b22", borderBottom: "1px solid #21262d" }}>
+                        {["Expediente", "Fecha resolución", "Tipo de medida", "Resultado"].map(
+                          (col) => (
+                            <th
+                              key={col}
+                              className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide"
+                              style={{ color: "#7d8590" }}
+                            >
+                              {col}
+                            </th>
+                          ),
+                        )}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {casos.map((caso, i) => (
+                        <tr
+                          key={caso.id}
+                          style={{
+                            backgroundColor: i % 2 === 0 ? "#0d1117" : "#161b22",
+                            borderBottom: "1px solid #21262d",
+                          }}
+                        >
+                          <td className="px-4 py-3 font-mono text-xs" style={{ color: "#74ACDF" }}>
+                            {caso.nroExpediente}
+                          </td>
+                          <td className="px-4 py-3" style={{ color: "#e6edf3" }}>
+                            {new Date(caso.fechaResolucion + "T00:00:00").toLocaleDateString(
+                              "es-AR",
+                              { day: "2-digit", month: "2-digit", year: "numeric" },
+                            )}
+                          </td>
+                          <td className="px-4 py-3" style={{ color: "#8b949e" }}>
+                            {caso.tipoMedida}
+                          </td>
+                          <td className="px-4 py-3">
+                            <ResultadoBadge resultado={caso.resultado} />
+                            {caso.observaciones && (
+                              <p className="mt-1 text-xs" style={{ color: "#7d8590" }}>
+                                {caso.observaciones}
+                              </p>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+          </section>
+
+          {/* Documents section */}
+          {!loadingCasos && archivos.length > 0 && (
+            <section className="mt-8">
+              <h2 className="mb-4 text-base font-bold" style={{ color: "#e6edf3" }}>
+                Documentación pública
+              </h2>
+              <div className="space-y-2">
+                {archivos.map((archivo) => (
+                  <a
+                    key={archivo.id}
+                    href={archivo.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center justify-between rounded-lg border px-4 py-3 transition-colors hover:border-[#74ACDF]/40"
+                    style={{ backgroundColor: "#161b22", borderColor: "#21262d" }}
+                  >
+                    <div className="flex items-center gap-3">
+                      <svg
+                        className="h-5 w-5 shrink-0"
+                        style={{ color: "#f85149" }}
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+                        />
+                      </svg>
+                      <span className="text-sm" style={{ color: "#e6edf3" }}>
+                        {archivo.nombre}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <span className="text-xs" style={{ color: "#7d8590" }}>
+                        {new Date(archivo.fechaCarga + "T00:00:00").toLocaleDateString("es-AR", {
+                          day: "2-digit",
+                          month: "2-digit",
+                          year: "numeric",
+                        })}
+                      </span>
+                      <svg
+                        className="h-4 w-4"
+                        style={{ color: "#74ACDF" }}
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                        />
+                      </svg>
+                    </div>
+                  </a>
+                ))}
+              </div>
+            </section>
+          )}
+        </>
+      )}
+    </main>
+  );
+}

--- a/app/juez/[id]/page.tsx
+++ b/app/juez/[id]/page.tsx
@@ -9,60 +9,56 @@ import {
   fetchJudgeCases,
   fetchJudges,
   Judge,
+  PaginatedResult,
   ResultadoCaso,
 } from "../../lib/api";
 
 // ── Mock data ─────────────────────────────────────────────────────────────────
-// Se usa como fallback hasta que el backend implemente GET /api/judges/:id/casos
-// y GET /api/judges/:id/archivos. Remover cuando estén disponibles.
+// Fallback cuando el backend no tiene los endpoints aún.
 
-const MOCK_CASOS: Caso[] = [
-  {
-    id: "mock-1",
-    nroExpediente: "12345/2024",
-    fechaResolucion: "2024-03-15",
-    tipoMedida: "Libertad cautelar",
-    resultado: "fta",
-    observaciones: "El imputado no se presentó a la audiencia fijada para el 20/04/2024.",
-  },
-  {
-    id: "mock-2",
-    nroExpediente: "98732/2024",
-    fechaResolucion: "2024-06-02",
-    tipoMedida: "Excarcelación",
-    resultado: "nuevo_arresto",
-    observaciones: "Detenido nuevamente el 14/07/2024 por robo agravado.",
-  },
-  {
-    id: "mock-3",
-    nroExpediente: "45210/2023",
-    fechaResolucion: "2023-11-20",
-    tipoMedida: "Prisión preventiva atenuada",
-    resultado: "revocada",
-    observaciones: "La Cámara revocó la medida por incumplimiento de condiciones.",
-  },
-  {
-    id: "mock-4",
-    nroExpediente: "67891/2025",
-    fechaResolucion: "2025-01-10",
-    tipoMedida: "Libertad cautelar",
-    resultado: "pendiente",
-  },
-];
+const MOCK_PAGINATED: PaginatedResult<Caso> = {
+  data: [
+    {
+      id: "mock-1",
+      nroExpediente: "12345/2024",
+      fechaResolucion: "2024-03-15",
+      tipoMedida: "Libertad cautelar",
+      resultado: "fta",
+      observaciones: "El imputado no se presentó a la audiencia fijada para el 20/04/2024.",
+    },
+    {
+      id: "mock-2",
+      nroExpediente: "98732/2024",
+      fechaResolucion: "2024-06-02",
+      tipoMedida: "Excarcelación",
+      resultado: "nuevo_arresto",
+      observaciones: "Detenido nuevamente el 14/07/2024 por robo agravado.",
+    },
+    {
+      id: "mock-3",
+      nroExpediente: "45210/2023",
+      fechaResolucion: "2023-11-20",
+      tipoMedida: "Prisión preventiva atenuada",
+      resultado: "revocada",
+      observaciones: "La Cámara revocó la medida por incumplimiento de condiciones.",
+    },
+    {
+      id: "mock-4",
+      nroExpediente: "67891/2025",
+      fechaResolucion: "2025-01-10",
+      tipoMedida: "Libertad cautelar",
+      resultado: "pendiente",
+    },
+  ],
+  total: 4,
+  page: 1,
+  limit: 10,
+  totalPages: 1,
+};
 
 const MOCK_ARCHIVOS: ArchivoPublico[] = [
-  {
-    id: "arch-1",
-    nombre: "Resolución 12345-2024.pdf",
-    url: "#",
-    fechaCarga: "2024-04-01",
-  },
-  {
-    id: "arch-2",
-    nombre: "Acta audiencia 98732-2024.pdf",
-    url: "#",
-    fechaCarga: "2024-07-20",
-  },
+  { id: "arch-1", nombre: "Resolución 12345-2024.pdf", url: "#", fechaCarga: "2024-04-01" },
+  { id: "arch-2", nombre: "Acta audiencia 98732-2024.pdf", url: "#", fechaCarga: "2024-07-20" },
 ];
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -109,21 +105,53 @@ function StatBox({ value, label, color }: { value: number; label: string; color:
   );
 }
 
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-0.5 py-2.5" style={{ borderBottom: "1px solid #21262d" }}>
+      <span className="text-xs font-medium uppercase tracking-wide" style={{ color: "#7d8590" }}>
+        {label}
+      </span>
+      <span className="text-sm" style={{ color: "#e6edf3" }}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function formatARS(amount: number) {
+  return new Intl.NumberFormat("es-AR", {
+    style: "currency",
+    currency: "ARS",
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+function formatDate(iso: string) {
+  return new Date(iso + "T00:00:00").toLocaleDateString("es-AR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
 // ── Componente principal ──────────────────────────────────────────────────────
+
+const LIMIT = 10;
 
 export default function JudgeDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const judgeId = Number(id);
 
   const [judge, setJudge] = useState<Judge | null>(null);
-  const [casos, setCasos] = useState<Caso[]>([]);
+  const [paginated, setPaginated] = useState<PaginatedResult<Caso> | null>(null);
   const [archivos, setArchivos] = useState<ArchivoPublico[]>([]);
+  const [page, setPage] = useState(1);
   const [loadingJudge, setLoadingJudge] = useState(true);
   const [loadingCasos, setLoadingCasos] = useState(true);
   const [errorJudge, setErrorJudge] = useState<string | null>(null);
   const [usingMockData, setUsingMockData] = useState(false);
 
-  // Cargar datos del juez desde la lista existente
+  // Cargar datos del juez
   useEffect(() => {
     let cancelled = false;
     async function load() {
@@ -146,24 +174,23 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ id: stri
     };
   }, [judgeId]);
 
-  // Cargar casos e archivos — con fallback a mock data
+  // Cargar casos paginados
   useEffect(() => {
     let cancelled = false;
     async function load() {
       setLoadingCasos(true);
       try {
         const [casosData, archivosData] = await Promise.all([
-          fetchJudgeCases(judgeId),
-          fetchJudgeArchivos(judgeId),
+          fetchJudgeCases(judgeId, page, LIMIT),
+          page === 1 ? fetchJudgeArchivos(judgeId) : Promise.resolve(archivos),
         ]);
         if (!cancelled) {
-          setCasos(casosData);
-          setArchivos(archivosData);
+          setPaginated(casosData);
+          if (page === 1) setArchivos(archivosData);
         }
       } catch {
-        // El endpoint aún no existe en el backend — usar datos de ejemplo
         if (!cancelled) {
-          setCasos(MOCK_CASOS);
+          setPaginated(MOCK_PAGINATED);
           setArchivos(MOCK_ARCHIVOS);
           setUsingMockData(true);
         }
@@ -175,7 +202,8 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ id: stri
     return () => {
       cancelled = true;
     };
-  }, [judgeId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [judgeId, page]);
 
   const failureRate =
     judge && judge.totalReleases > 0
@@ -214,7 +242,7 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ id: stri
         Volver al dashboard
       </Link>
 
-      {/* Error state */}
+      {/* Error */}
       {errorJudge && !loadingJudge && (
         <div
           className="rounded-lg border px-4 py-3 text-sm"
@@ -238,22 +266,35 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ id: stri
         </div>
       )}
 
-      {/* Judge header */}
       {!loadingJudge && judge && (
         <>
+          {/* ── Header ─────────────────────────────────────────────────────── */}
           <article
-            className="rounded-xl border overflow-hidden mb-6"
+            className="mb-6 overflow-hidden rounded-xl border"
             style={{ backgroundColor: "#161b22", borderColor: "#21262d" }}
           >
-            {/* Header */}
             <div
               className="flex flex-wrap items-start justify-between gap-3 px-6 py-5"
               style={{ borderBottom: "1px solid #21262d" }}
             >
               <div className="min-w-0">
-                <h1 className="text-xl font-bold" style={{ color: "#e6edf3" }}>
-                  {judge.name}
-                </h1>
+                <div className="flex items-center gap-2">
+                  <h1 className="text-xl font-bold" style={{ color: "#e6edf3" }}>
+                    {judge.name}
+                  </h1>
+                  {judge.isDemoData && (
+                    <span
+                      className="rounded-full px-2 py-0.5 text-xs"
+                      style={{
+                        backgroundColor: "#d2992215",
+                        color: "#d29922",
+                        border: "1px solid #d2992230",
+                      }}
+                    >
+                      Demo
+                    </span>
+                  )}
+                </div>
                 <p className="mt-1 text-sm" style={{ color: "#74ACDF" }}>
                   {judge.court}
                 </p>
@@ -294,15 +335,128 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ id: stri
             </div>
           </article>
 
-          {/* Mock data notice */}
+          {/* ── Info del cargo ─────────────────────────────────────────────── */}
+          <section
+            className="mb-6 overflow-hidden rounded-xl border"
+            style={{ backgroundColor: "#161b22", borderColor: "#21262d" }}
+          >
+            <div className="px-5 py-3" style={{ borderBottom: "1px solid #21262d" }}>
+              <h2 className="text-sm font-semibold" style={{ color: "#e6edf3" }}>
+                Datos del cargo
+              </h2>
+            </div>
+            <div className="grid gap-x-8 px-5 sm:grid-cols-2">
+              <div>
+                <InfoRow label="Fuero" value={judge.jurisdiction?.fuero ?? "—"} />
+                <InfoRow label="Instancia" value={judge.jurisdiction?.instance ?? "—"} />
+                <InfoRow
+                  label="Alcance / Competencia"
+                  value={
+                    judge.jurisdiction
+                      ? `${judge.jurisdiction.scope} / ${judge.jurisdiction.competence}`
+                      : "—"
+                  }
+                />
+                <InfoRow label="Domicilio laboral" value={judge.workAddress ?? "—"} />
+              </div>
+              <div>
+                <InfoRow label="Horario de atención" value={judge.workHours ?? "—"} />
+                <InfoRow label="Designado por" value={judge.appointmentBody ?? "—"} />
+                <InfoRow label="Fecha de designación" value={judge.appointmentDate ?? "—"} />
+                <InfoRow
+                  label="Antigüedad en el cargo"
+                  value={judge.yearsOnBench != null ? `${judge.yearsOnBench} años` : "—"}
+                />
+              </div>
+            </div>
+            {/* Remuneración */}
+            {judge.salary && (
+              <div className="mx-5 py-2.5" style={{ borderBottom: "1px solid #21262d" }}>
+                <span
+                  className="text-xs font-medium uppercase tracking-wide"
+                  style={{ color: "#7d8590" }}
+                >
+                  Remuneración bruta mensual
+                </span>
+                <div className="mt-1 flex flex-wrap items-baseline gap-2">
+                  <span className="text-lg font-bold" style={{ color: "#3fb950" }}>
+                    {formatARS(judge.salary.grossMonthlyARS)}
+                  </span>
+                  <span className="text-xs" style={{ color: "#7d8590" }}>
+                    {judge.salary.category} — {judge.salary.acordada} ({judge.salary.lastUpdated})
+                  </span>
+                </div>
+              </div>
+            )}
+            {/* Bio */}
+            {judge.publicBio && (
+              <div className="px-5 py-3">
+                <span
+                  className="text-xs font-medium uppercase tracking-wide"
+                  style={{ color: "#7d8590" }}
+                >
+                  Biografía pública
+                </span>
+                <p className="mt-1 text-sm leading-relaxed" style={{ color: "#8b949e" }}>
+                  {judge.publicBio}
+                </p>
+              </div>
+            )}
+          </section>
+
+          {/* ── Fuentes ────────────────────────────────────────────────────── */}
+          {judge.sourceLinks && judge.sourceLinks.length > 0 && (
+            <section
+              className="mb-6 overflow-hidden rounded-xl border"
+              style={{ backgroundColor: "#161b22", borderColor: "#21262d" }}
+            >
+              <div className="px-5 py-3" style={{ borderBottom: "1px solid #21262d" }}>
+                <h2 className="text-sm font-semibold" style={{ color: "#e6edf3" }}>
+                  Fuentes oficiales
+                </h2>
+              </div>
+              <div className="divide-y" style={{ borderColor: "#21262d" }}>
+                {judge.sourceLinks.map((link, i) => (
+                  <a
+                    key={i}
+                    href={link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-start gap-3 px-5 py-3 transition-colors hover:bg-white/5"
+                  >
+                    <svg
+                      className="mt-0.5 h-4 w-4 shrink-0"
+                      style={{ color: "#74ACDF" }}
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                      />
+                    </svg>
+                    <div>
+                      <p className="text-sm font-medium" style={{ color: "#74ACDF" }}>
+                        {link.label}
+                      </p>
+                      <p className="text-xs" style={{ color: "#7d8590" }}>
+                        {link.description}
+                      </p>
+                    </div>
+                  </a>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* ── Mock data notice ────────────────────────────────────────────── */}
           {usingMockData && (
             <div
               className="mb-5 flex items-start gap-3 rounded-lg border px-4 py-3 text-sm"
-              style={{
-                backgroundColor: "#d2992210",
-                borderColor: "#d2992240",
-                color: "#d29922",
-              }}
+              style={{ backgroundColor: "#d2992210", borderColor: "#d2992240", color: "#d29922" }}
             >
               <svg
                 className="mt-0.5 h-4 w-4 shrink-0"
@@ -322,23 +476,23 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ id: stri
                 <code className="rounded px-1 text-xs" style={{ backgroundColor: "#21262d" }}>
                   GET /api/judges/:id/casos
                 </code>{" "}
-                aún no está implementado en el backend. Los casos mostrados son ficticios.
+                aún no está disponible. Los casos mostrados son ficticios.
               </span>
             </div>
           )}
 
-          {/* Cases section */}
-          <section>
+          {/* ── Casos ──────────────────────────────────────────────────────── */}
+          <section className="mb-6">
             <div className="mb-4 flex items-center gap-2">
               <h2 className="text-base font-bold" style={{ color: "#e6edf3" }}>
                 Casos registrados
               </h2>
-              {!loadingCasos && (
+              {paginated && (
                 <span
                   className="rounded-full px-2 py-0.5 text-xs font-semibold"
                   style={{ backgroundColor: "#21262d", color: "#7d8590" }}
                 >
-                  {casos.length}
+                  {paginated.total}
                 </span>
               )}
             </div>
@@ -348,7 +502,7 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ id: stri
                 className="h-40 animate-pulse rounded-xl border"
                 style={{ backgroundColor: "#161b22", borderColor: "#21262d" }}
               />
-            ) : casos.length === 0 ? (
+            ) : !paginated || paginated.data.length === 0 ? (
               <div
                 className="flex flex-col items-center justify-center rounded-xl border py-12"
                 style={{ borderColor: "#21262d", backgroundColor: "#161b22" }}
@@ -361,65 +515,108 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ id: stri
                 </p>
               </div>
             ) : (
-              <div className="overflow-hidden rounded-xl border" style={{ borderColor: "#21262d" }}>
-                <div className="overflow-x-auto">
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr style={{ backgroundColor: "#161b22", borderBottom: "1px solid #21262d" }}>
-                        {["Expediente", "Fecha resolución", "Tipo de medida", "Resultado"].map(
-                          (col) => (
-                            <th
-                              key={col}
-                              className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide"
-                              style={{ color: "#7d8590" }}
-                            >
-                              {col}
-                            </th>
-                          ),
-                        )}
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {casos.map((caso, i) => (
+              <>
+                <div
+                  className="overflow-hidden rounded-xl border"
+                  style={{ borderColor: "#21262d" }}
+                >
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
                         <tr
-                          key={caso.id}
-                          style={{
-                            backgroundColor: i % 2 === 0 ? "#0d1117" : "#161b22",
-                            borderBottom: "1px solid #21262d",
-                          }}
+                          style={{ backgroundColor: "#161b22", borderBottom: "1px solid #21262d" }}
                         >
-                          <td className="px-4 py-3 font-mono text-xs" style={{ color: "#74ACDF" }}>
-                            {caso.nroExpediente}
-                          </td>
-                          <td className="px-4 py-3" style={{ color: "#e6edf3" }}>
-                            {new Date(caso.fechaResolucion + "T00:00:00").toLocaleDateString(
-                              "es-AR",
-                              { day: "2-digit", month: "2-digit", year: "numeric" },
-                            )}
-                          </td>
-                          <td className="px-4 py-3" style={{ color: "#8b949e" }}>
-                            {caso.tipoMedida}
-                          </td>
-                          <td className="px-4 py-3">
-                            <ResultadoBadge resultado={caso.resultado} />
-                            {caso.observaciones && (
-                              <p className="mt-1 text-xs" style={{ color: "#7d8590" }}>
-                                {caso.observaciones}
-                              </p>
-                            )}
-                          </td>
+                          {["Expediente", "Fecha resolución", "Tipo de medida", "Resultado"].map(
+                            (col) => (
+                              <th
+                                key={col}
+                                className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide"
+                                style={{ color: "#7d8590" }}
+                              >
+                                {col}
+                              </th>
+                            ),
+                          )}
                         </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                      </thead>
+                      <tbody>
+                        {paginated.data.map((caso, i) => (
+                          <tr
+                            key={caso.id}
+                            style={{
+                              backgroundColor: i % 2 === 0 ? "#0d1117" : "#161b22",
+                              borderBottom: "1px solid #21262d",
+                            }}
+                          >
+                            <td
+                              className="px-4 py-3 font-mono text-xs"
+                              style={{ color: "#74ACDF" }}
+                            >
+                              {caso.nroExpediente}
+                            </td>
+                            <td className="px-4 py-3" style={{ color: "#e6edf3" }}>
+                              {formatDate(caso.fechaResolucion)}
+                            </td>
+                            <td className="px-4 py-3" style={{ color: "#8b949e" }}>
+                              {caso.tipoMedida}
+                            </td>
+                            <td className="px-4 py-3">
+                              <ResultadoBadge resultado={caso.resultado} />
+                              {caso.observaciones && (
+                                <p className="mt-1 text-xs" style={{ color: "#7d8590" }}>
+                                  {caso.observaciones}
+                                </p>
+                              )}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
-              </div>
+
+                {/* Paginación */}
+                {paginated.totalPages > 1 && (
+                  <div className="mt-4 flex items-center justify-between">
+                    <span className="text-xs" style={{ color: "#7d8590" }}>
+                      Página {paginated.page} de {paginated.totalPages} — {paginated.total} casos en
+                      total
+                    </span>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => setPage((p) => p - 1)}
+                        disabled={paginated.page === 1}
+                        className="rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-40"
+                        style={{
+                          backgroundColor: "#21262d",
+                          color: "#e6edf3",
+                          border: "1px solid #30363d",
+                        }}
+                      >
+                        ← Anterior
+                      </button>
+                      <button
+                        onClick={() => setPage((p) => p + 1)}
+                        disabled={paginated.page === paginated.totalPages}
+                        className="rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-40"
+                        style={{
+                          backgroundColor: "#21262d",
+                          color: "#e6edf3",
+                          border: "1px solid #30363d",
+                        }}
+                      >
+                        Siguiente →
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </>
             )}
           </section>
 
-          {/* Documents section */}
-          {!loadingCasos && archivos.length > 0 && (
-            <section className="mt-8">
+          {/* ── Documentación pública ──────────────────────────────────────── */}
+          {archivos.length > 0 && (
+            <section>
               <h2 className="mb-4 text-base font-bold" style={{ color: "#e6edf3" }}>
                 Documentación pública
               </h2>
@@ -454,11 +651,7 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ id: stri
                     </div>
                     <div className="flex items-center gap-3">
                       <span className="text-xs" style={{ color: "#7d8590" }}>
-                        {new Date(archivo.fechaCarga + "T00:00:00").toLocaleDateString("es-AR", {
-                          day: "2-digit",
-                          month: "2-digit",
-                          year: "numeric",
-                        })}
+                        {formatDate(archivo.fechaCarga)}
                       </span>
                       <svg
                         className="h-4 w-4"

--- a/app/juez/[slug]/layout.tsx
+++ b/app/juez/[slug]/layout.tsx
@@ -1,0 +1,54 @@
+import { Metadata } from "next";
+import { fetchJudgeBySlug } from "../../lib/api";
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+
+  try {
+    const judge = await fetchJudgeBySlug(slug);
+    const province = judge.location.province;
+    const court = judge.court;
+    const failureRate = judge.failureRate?.toFixed(1) ?? "—";
+
+    const title = `${judge.name} | Observatorio de Justicia Argentina`;
+    const description =
+      `${judge.name} — ${court} (${province}). ` +
+      `Tasa de fracasos en libertades otorgadas: ${failureRate}%. ` +
+      `Conocé su historial de resoluciones, causas y datos públicos.`;
+
+    return {
+      title,
+      description,
+      openGraph: {
+        title,
+        description,
+        url: `/juez/${slug}`,
+        siteName: "Observatorio de Justicia Argentina",
+        locale: "es_AR",
+        type: "profile",
+      },
+      twitter: {
+        card: "summary",
+        title,
+        description,
+      },
+      alternates: {
+        canonical: `/juez/${slug}`,
+      },
+    };
+  } catch {
+    return {
+      title: "Perfil de juez | Observatorio de Justicia Argentina",
+      description:
+        "Información pública sobre magistrados del Poder Judicial de la República Argentina.",
+    };
+  }
+}
+
+export default function JudgeLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/juez/[slug]/page.tsx
+++ b/app/juez/[slug]/page.tsx
@@ -171,17 +171,15 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ slug: st
     };
   }, [slug]);
 
-  // Cargar casos paginados (usa el ID numérico interno del juez)
-  const judgeId = judge?.id ?? 0;
+  // Cargar casos paginados
   useEffect(() => {
-    if (!judgeId) return;
     let cancelled = false;
     async function load() {
       setLoadingCasos(true);
       try {
         const [casosData, archivosData] = await Promise.all([
-          fetchJudgeCases(judgeId, page, LIMIT),
-          page === 1 ? fetchJudgeArchivos(judgeId) : Promise.resolve(archivos),
+          fetchJudgeCases(slug, page, LIMIT),
+          page === 1 ? fetchJudgeArchivos(slug) : Promise.resolve(archivos),
         ]);
         if (!cancelled) {
           setPaginated(casosData);
@@ -201,8 +199,7 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ slug: st
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [judgeId, page]);
+  }, [slug, page]);
 
   const failureRate =
     judge && judge.totalReleases > 0

--- a/app/juez/[slug]/page.tsx
+++ b/app/juez/[slug]/page.tsx
@@ -7,7 +7,7 @@ import {
   Caso,
   fetchJudgeArchivos,
   fetchJudgeCases,
-  fetchJudges,
+  fetchJudgeBySlug,
   Judge,
   PaginatedResult,
   ResultadoCaso,
@@ -138,9 +138,8 @@ function formatDate(iso: string) {
 
 const LIMIT = 10;
 
-export default function JudgeDetailPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = use(params);
-  const judgeId = Number(id);
+export default function JudgeDetailPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = use(params);
 
   const [judge, setJudge] = useState<Judge | null>(null);
   const [paginated, setPaginated] = useState<PaginatedResult<Caso> | null>(null);
@@ -151,16 +150,14 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ id: stri
   const [errorJudge, setErrorJudge] = useState<string | null>(null);
   const [usingMockData, setUsingMockData] = useState(false);
 
-  // Cargar datos del juez
+  // Cargar datos del juez por slug
   useEffect(() => {
     let cancelled = false;
     async function load() {
       try {
-        const judges = await fetchJudges();
+        const found = await fetchJudgeBySlug(slug);
         if (!cancelled) {
-          const found = judges.find((j) => j.id === judgeId) ?? null;
           setJudge(found);
-          if (!found) setErrorJudge("Juez no encontrado.");
         }
       } catch {
         if (!cancelled) setErrorJudge("No se pudo conectar con el backend.");
@@ -172,10 +169,12 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ id: stri
     return () => {
       cancelled = true;
     };
-  }, [judgeId]);
+  }, [slug]);
 
-  // Cargar casos paginados
+  // Cargar casos paginados (usa el ID numérico interno del juez)
+  const judgeId = judge?.id ?? 0;
   useEffect(() => {
+    if (!judgeId) return;
     let cancelled = false;
     async function load() {
       setLoadingCasos(true);

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -164,6 +164,14 @@ export interface ArchivoPublico {
   fechaCarga: string; // ISO date
 }
 
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
 // ── Fetch ────────────────────────────────────────────────────────────────────
 
 export async function fetchJudges(): Promise<Judge[]> {
@@ -178,8 +186,12 @@ export async function fetchHierarchy(): Promise<JurisdictionNode> {
   return res.json();
 }
 
-export async function fetchJudgeCases(id: number): Promise<Caso[]> {
-  const res = await fetch(`${API_BASE}/judges/${id}/casos`);
+export async function fetchJudgeCases(
+  id: number,
+  page = 1,
+  limit = 10,
+): Promise<PaginatedResult<Caso>> {
+  const res = await fetch(`${API_BASE}/judges/${id}/casos?page=${page}&limit=${limit}`);
   if (!res.ok) throw new Error(`Error ${res.status} al cargar casos del juez`);
   return res.json();
 }

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -188,17 +188,17 @@ export async function fetchHierarchy(): Promise<JurisdictionNode> {
 }
 
 export async function fetchJudgeCases(
-  id: number,
+  slug: string,
   page = 1,
   limit = 10,
 ): Promise<PaginatedResult<Caso>> {
-  const res = await fetch(`${API_BASE}/judges/${id}/casos?page=${page}&limit=${limit}`);
+  const res = await fetch(`${API_BASE}/judges/${slug}/casos?page=${page}&limit=${limit}`);
   if (!res.ok) throw new Error(`Error ${res.status} al cargar casos del juez`);
   return res.json();
 }
 
-export async function fetchJudgeArchivos(id: number): Promise<ArchivoPublico[]> {
-  const res = await fetch(`${API_BASE}/judges/${id}/archivos`);
+export async function fetchJudgeArchivos(slug: string): Promise<ArchivoPublico[]> {
+  const res = await fetch(`${API_BASE}/judges/${slug}/archivos`);
   if (!res.ok) throw new Error(`Error ${res.status} al cargar archivos del juez`);
   return res.json();
 }

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -144,6 +144,26 @@ export interface JurisdictionNode {
   children?: JurisdictionNode[];
 }
 
+// ── Tipos de detalle de juez (endpoint /judges/:id/casos y /archivos) ────────
+
+export type ResultadoCaso = "fta" | "nuevo_arresto" | "revocada" | "pendiente";
+
+export interface Caso {
+  id: string;
+  nroExpediente: string;
+  fechaResolucion: string; // ISO date (YYYY-MM-DD)
+  tipoMedida: string;
+  resultado: ResultadoCaso;
+  observaciones?: string;
+}
+
+export interface ArchivoPublico {
+  id: string;
+  nombre: string;
+  url: string;
+  fechaCarga: string; // ISO date
+}
+
 // ── Fetch ────────────────────────────────────────────────────────────────────
 
 export async function fetchJudges(): Promise<Judge[]> {
@@ -155,5 +175,17 @@ export async function fetchJudges(): Promise<Judge[]> {
 export async function fetchHierarchy(): Promise<JurisdictionNode> {
   const res = await fetch(`${API_BASE}/stats/hierarchy`);
   if (!res.ok) throw new Error(`Error ${res.status} al cargar jerarquía`);
+  return res.json();
+}
+
+export async function fetchJudgeCases(id: number): Promise<Caso[]> {
+  const res = await fetch(`${API_BASE}/judges/${id}/casos`);
+  if (!res.ok) throw new Error(`Error ${res.status} al cargar casos del juez`);
+  return res.json();
+}
+
+export async function fetchJudgeArchivos(id: number): Promise<ArchivoPublico[]> {
+  const res = await fetch(`${API_BASE}/judges/${id}/archivos`);
+  if (!res.ok) throw new Error(`Error ${res.status} al cargar archivos del juez`);
   return res.json();
 }

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -83,6 +83,7 @@ export interface JudgeExtendedStats {
 
 export interface Judge {
   id: number;
+  slug: string;
   isDemoData: boolean;
   name: string;
   court: string;
@@ -199,5 +200,11 @@ export async function fetchJudgeCases(
 export async function fetchJudgeArchivos(id: number): Promise<ArchivoPublico[]> {
   const res = await fetch(`${API_BASE}/judges/${id}/archivos`);
   if (!res.ok) throw new Error(`Error ${res.status} al cargar archivos del juez`);
+  return res.json();
+}
+
+export async function fetchJudgeBySlug(slug: string): Promise<Judge> {
+  const res = await fetch(`${API_BASE}/judges/${slug}`);
+  if (!res.ok) throw new Error(`Error ${res.status} al cargar el juez`);
   return res.json();
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import JudgeCard from "./components/JudgeCard";
 import JudgeFilters, { FilterState, applyFilters } from "./components/JudgeFilters";
 import JurisdictionStats from "./components/JurisdictionStats";
 import StatsBar from "./components/StatsBar";
+import Link from "next/link";
 import { fetchHierarchy, fetchJudges, Judge, JurisdictionNode } from "./lib/api";
 
 // El mapa usa APIs del browser (SVG + eventos de mouse) — se carga solo en el cliente
@@ -225,7 +226,13 @@ export default function HomePage() {
         {!loading && !error && filtered.length > 0 && (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {filtered.map((judge) => (
-              <JudgeCard key={judge.id} {...judge} />
+              <Link
+                key={judge.id}
+                href={`/juez/${judge.id}`}
+                className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-[#74ACDF] rounded-xl"
+              >
+                <JudgeCard {...judge} />
+              </Link>
             ))}
           </div>
         )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -228,7 +228,7 @@ export default function HomePage() {
             {filtered.map((judge) => (
               <Link
                 key={judge.id}
-                href={`/juez/${judge.id}`}
+                href={`/juez/${judge.slug}`}
                 className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-[#74ACDF] rounded-xl"
               >
                 <JudgeCard {...judge} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1936,6 +1937,7 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1946,6 +1948,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2005,6 +2008,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -2530,6 +2534,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2909,6 +2914,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3258,6 +3264,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -3759,6 +3766,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3944,6 +3952,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6518,6 +6527,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6527,6 +6537,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7358,6 +7369,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7520,6 +7532,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7961,6 +7974,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## ¿Qué incluye este PR?

### Página de detalle del juez
- Perfil completo: cargo, jurisdicción, remuneración, designación, trayectoria
- Secciones opcionales: biografía pública, formación, carrera, resoluciones notables, estadísticas extendidas
- Tabla de casos paginada con badge por resultado (FTA / nuevo arresto / revocada / pendiente)
- Listado de archivos públicos vinculados
- Fallback a datos mock si el backend no responde

### URLs semánticas (SEO)
- Ruta migrada de `/juez/[id]` a `/juez/[slug]`
- Campo `slug` en la interfaz `Judge` — ej: `juan-carlos-perez-gomez-caba`
- `fetchJudgeBySlug(slug)` → `GET /judges/:slug`
- Links en la home actualizados para usar slug
- Las llamadas internas a casos/archivos siguen usando `judge.id` (numérico)

### Metadata dinámica por perfil
- `generateMetadata()` en `app/juez/[slug]/layout.tsx` (server component)
- `<title>`, `<meta description>`, OpenGraph y Twitter Card con nombre del juez, tribunal, provincia y tasa de fracasos
- Fallback genérico si el backend no responde

### Fixes y mejoras menores
- Optional chaining en `jurisdiction` para evitar crash con datos incompletos
- Sincronización de dependencias

## Commits
- `f0cc72b` feat(judges): agregar página de detalle con casos y documentación pública
- `7da776d` fix(filters): optional chaining en jurisdiction para evitar crash
- `9b5fa91` docs(readme): corregir URLs del repositorio
- `90a1dd7` feat(judges): enriquecer detalle con datos del cargo y paginación de casos
- `8f4f9db` feat(judges): migrar rutas de /juez/[id] a /juez/[slug] para SEO
- `20bc59d` feat(seo): agregar generateMetadata dinámico en páginas de perfil de juez

## Dependencia
Requiere que el PR de backend esté mergeado antes del deploy para que `fetchJudgeBySlug` resuelva correctamente.