### PR TITLE
perf(hero): stutter del efecto spotlight en escudo

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -197,6 +197,13 @@ body {
   mix-blend-mode: soft-light;
 }
 
+@media (hover: none), (pointer: coarse) {
+  .escudo-spot,
+  .escudo-halo {
+    display: none;
+  }
+}
+
 /* Modal / overlay reveal */
 @keyframes fadeIn {
   from {

--- a/app/globals.css
+++ b/app/globals.css
@@ -185,16 +185,13 @@ body {
   );
 }
 
-/* Gold halo that tracks the same cursor position, soft-light blended so it
-   reads as warm illumination behind the spotlight rather than a highlight on top. */
 .escudo-halo {
   background: radial-gradient(
     circle 380px at var(--spot-x) var(--spot-y),
-    rgba(208, 160, 74, 0.22) 0%,
-    rgba(208, 160, 74, 0.08) 40%,
+    rgba(208, 160, 74, 0.12) 0%,
+    rgba(208, 160, 74, 0.04) 40%,
     transparent 75%
   );
-  mix-blend-mode: soft-light;
 }
 
 @media (hover: none), (pointer: coarse) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -164,12 +164,9 @@ body {
   initial-value: -400px;
 }
 
-/* Escudo spotlight — multi-stop soft radial mask tracks the cursor with a 150ms trail.
+/* Escudo spotlight — multi-stop soft radial mask tracks the cursor.
    The mask uses alpha values for a smooth feathered edge instead of a hard cutoff. */
 .escudo-spot {
-  transition:
-    --spot-x 150ms cubic-bezier(0.2, 0.8, 0.2, 1),
-    --spot-y 150ms cubic-bezier(0.2, 0.8, 0.2, 1);
   mask-image: radial-gradient(
     circle 320px at var(--spot-x) var(--spot-y),
     rgba(0, 0, 0, 1) 0%,
@@ -191,9 +188,6 @@ body {
 /* Gold halo that tracks the same cursor position, soft-light blended so it
    reads as warm illumination behind the spotlight rather than a highlight on top. */
 .escudo-halo {
-  transition:
-    --spot-x 150ms cubic-bezier(0.2, 0.8, 0.2, 1),
-    --spot-y 150ms cubic-bezier(0.2, 0.8, 0.2, 1);
   background: radial-gradient(
     circle 380px at var(--spot-x) var(--spot-y),
     rgba(208, 160, 74, 0.22) 0%,


### PR DESCRIPTION
## Descripción

El efecto spotlight del escudo en el Hero generaba stutter notable. Tres optimizaciones CSS-only sobre `app/globals.css`, sin cambio de comportamiento ni visual en desktop más allá del halo.

**Causas**:

1. Las custom properties `--spot-x`/`--spot-y` estaban registradas con `@property` como `<length>` y animadas con `transition: 150ms`. El navegador interpolaba la posición y recomputaba la `mask-image`/`background` radial en cada frame durante esos 150ms después de cada `mousemove`, sobre dos SVGs de 2480×3507.
2. `.escudo-halo` tenía `mix-blend-mode: soft-light` fullscreen — forzaba un compositing layer aislado que impactaba cada paint, incluso en scroll sin mousemove.
3. En touch/mobile el spotlight es invisible (el mousemove nunca dispara), pero las capas igual se rasterizaban y compositaban sin beneficio.

**Cambios**:

- Eliminadas las dos `transition` sobre las custom properties. El handler JS en `Hero.tsx` ya throttlea con `requestAnimationFrame`, así que la suavidad del efecto no depende del CSS.
- Eliminado `mix-blend-mode: soft-light` del halo y bajadas las alphas del gradiente (0.22 → 0.12, 0.08 → 0.04) para compensar la mayor visibilidad sin blend.
- `@media (hover: none), (pointer: coarse)` con `display: none` sobre `.escudo-spot` y `.escudo-halo` para ahorrar raster + composite en touch.

## Tipo de cambio

- [x] `perf` — mejora de performance

## Issue relacionado

No hay.

## ¿Cómo probarlo?

1. Abrir la home en una máquina con GPU integrada (o limitar el CPU 4–6× en Chrome DevTools → Performance).
2. Pasar el mouse por encima del Hero con movimientos rápidos y frenadas en seco.
3. Comparar contra prod: el spotlight debería seguir el cursor sin el "tirón" de inercia al frenar, y no dropear frames.
4. En mobile/tablet (o emulando touch en DevTools): el escudo debería verse en gris halftone sin el overlay color ni el halo.

## Checklist obligatorio

- [x] El CI está en verde (lint + typecheck + build)
- [x] Los commits siguen el formato Conventional Commits
- [x] No hay `console.log` ni código de debug en el PR
- [x] No hay valores hardcodeados que deberían ir en variables de entorno
- [x] Si cambié la API, actualicé la documentación (README / tipos) — N/A
- [x] Si agregué una dependencia, justifiqué por qué en la descripción — N/A
- [x] El PR apunta a `develop`, no a `main`

## Notas para el revisor

- Trade-off visual: el halo pierde el look "soft-light" (que teñía cálidamente el fondo) y queda como un gold glow directo con alpha baja. Si preferís conservarlo tal cual, se puede mantener el `mix-blend-mode` pero gateándolo con `:hover` del section parent — así el compositing solo cuesta durante interacción activa.
- El SVG `coat-of-arms.svg` sigue siendo 2480×3507 aunque se renderice a ~1000px. Ideal optimizarlo, pero es cambio de asset, mejor en un PR aparte.