### PR TITLE
feat(expediente-reputacional): Fase 1 — sección de trayectoria en perfil del juez

### DIFF
--- a/app/juez/[slug]/page.tsx
+++ b/app/juez/[slug]/page.tsx
@@ -328,6 +328,206 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ slug: st
             )}
           </section>
 
+          {/* ── Expediente Reputacional ─────────────────────────────────── */}
+          {(judge.appointmentDetail || (judge.associations && judge.associations.length > 0)) && (
+            <section
+              className="mb-6 overflow-hidden rounded-xl border"
+              style={{ backgroundColor: "#161b22", borderColor: "#21262d" }}
+            >
+              <div className="px-5 py-3" style={{ borderBottom: "1px solid #21262d" }}>
+                <h2 className="text-sm font-semibold" style={{ color: "#e6edf3" }}>
+                  Expediente reputacional
+                </h2>
+              </div>
+
+              {/* Origen de designación */}
+              {judge.appointmentDetail &&
+                (() => {
+                  const d = judge.appointmentDetail;
+                  const originConfig: Record<string, { label: string; color: string }> = {
+                    judicial: { label: "Carrera judicial pura", color: "#3fb950" },
+                    academic: { label: "Origen académico", color: "#74ACDF" },
+                    mixed: { label: "Trayectoria mixta", color: "#F4B942" },
+                    political: { label: "Designación política", color: "#f85149" },
+                  };
+                  const cfg = originConfig[d.politicalOrigin];
+                  return (
+                    <div className="px-5 py-4" style={{ borderBottom: "1px solid #21262d" }}>
+                      <p
+                        className="mb-3 text-xs font-bold uppercase tracking-wider"
+                        style={{ color: "#7d8590" }}
+                      >
+                        Origen de la designación
+                      </p>
+                      <span
+                        className="mb-3 inline-block rounded-full px-3 py-1 text-xs font-semibold"
+                        style={{
+                          backgroundColor: cfg.color + "20",
+                          color: cfg.color,
+                          border: `1px solid ${cfg.color}40`,
+                        }}
+                      >
+                        {cfg.label}
+                      </span>
+                      {d.politicalOriginDetail && (
+                        <p className="mt-2 text-xs leading-relaxed" style={{ color: "#8b949e" }}>
+                          {d.politicalOriginDetail}
+                        </p>
+                      )}
+
+                      {/* Concurso Magistratura */}
+                      {(d.magistraturaScore !== undefined || d.magistraturaRank !== undefined) && (
+                        <div className="mt-4 flex flex-wrap gap-3">
+                          {d.magistraturaCompetitionId && (
+                            <div
+                              className="flex-1 rounded-lg px-3 py-2"
+                              style={{ backgroundColor: "#0d1117", minWidth: "180px" }}
+                            >
+                              <p className="text-xs" style={{ color: "#7d8590" }}>
+                                Concurso
+                              </p>
+                              <p
+                                className="mt-0.5 text-xs font-medium"
+                                style={{ color: "#e6edf3" }}
+                              >
+                                {d.magistraturaSourceUrl ? (
+                                  <a
+                                    href={d.magistraturaSourceUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="hover:underline"
+                                    style={{ color: "#74ACDF" }}
+                                  >
+                                    {d.magistraturaCompetitionId}
+                                  </a>
+                                ) : (
+                                  d.magistraturaCompetitionId
+                                )}
+                              </p>
+                            </div>
+                          )}
+                          {d.magistraturaScore !== undefined && (
+                            <div
+                              className="rounded-lg px-3 py-2"
+                              style={{ backgroundColor: "#0d1117" }}
+                            >
+                              <p className="text-xs" style={{ color: "#7d8590" }}>
+                                Puntaje
+                              </p>
+                              <p className="mt-0.5 text-sm font-bold" style={{ color: "#e6edf3" }}>
+                                {d.magistraturaScore.toFixed(1)}
+                              </p>
+                            </div>
+                          )}
+                          {d.magistraturaRank !== undefined && (
+                            <div
+                              className="rounded-lg px-3 py-2"
+                              style={{ backgroundColor: "#0d1117" }}
+                            >
+                              <p className="text-xs" style={{ color: "#7d8590" }}>
+                                Puesto en mérito
+                              </p>
+                              <p className="mt-0.5 text-sm font-bold" style={{ color: "#e6edf3" }}>
+                                #{d.magistraturaRank}
+                              </p>
+                            </div>
+                          )}
+                        </div>
+                      )}
+
+                      {/* Senado */}
+                      {d.senateSession && (
+                        <div className="mt-4">
+                          <p className="mb-1.5 text-xs font-medium" style={{ color: "#7d8590" }}>
+                            Acuerdo del Senado
+                            {d.senateSession !==
+                              "N/A — designación provincial (acuerdo de la Legislatura de Buenos Aires)" && (
+                              <span className="ml-2 font-normal">{d.senateSession}</span>
+                            )}
+                            {d.senateSession.startsWith("N/A") && (
+                              <span className="ml-2 font-normal">{d.senateSession}</span>
+                            )}
+                          </p>
+                          {d.senateBackers && d.senateBackers.length > 0 && (
+                            <div className="flex flex-wrap gap-1.5">
+                              {d.senateBackers.map((backer, i) => (
+                                <span
+                                  key={i}
+                                  className="rounded px-2 py-0.5 text-xs"
+                                  style={{ backgroundColor: "#21262d", color: "#8b949e" }}
+                                >
+                                  {backer}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                          {d.senateRecordUrl && (
+                            <a
+                              href={d.senateRecordUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="mt-2 inline-block text-xs hover:underline"
+                              style={{ color: "#74ACDF" }}
+                            >
+                              ↗ Ver versión taquigráfica
+                            </a>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })()}
+
+              {/* Asociaciones */}
+              {judge.associations && judge.associations.length > 0 && (
+                <div className="px-5 py-4">
+                  <p
+                    className="mb-3 text-xs font-bold uppercase tracking-wider"
+                    style={{ color: "#7d8590" }}
+                  >
+                    Vínculos institucionales
+                  </p>
+                  <div className="flex flex-col gap-3">
+                    {judge.associations.map((assoc, i) => (
+                      <div key={i} className="flex items-start justify-between gap-3">
+                        <div>
+                          {assoc.sourceUrl ? (
+                            <a
+                              href={assoc.sourceUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-sm font-medium hover:underline"
+                              style={{ color: "#74ACDF" }}
+                            >
+                              {assoc.name}
+                            </a>
+                          ) : (
+                            <p className="text-sm font-medium" style={{ color: "#e6edf3" }}>
+                              {assoc.name}
+                            </p>
+                          )}
+                          {assoc.role && (
+                            <p className="text-xs" style={{ color: "#7d8590" }}>
+                              {assoc.role}
+                            </p>
+                          )}
+                        </div>
+                        {assoc.since && (
+                          <span
+                            className="shrink-0 rounded px-2 py-0.5 font-mono text-xs"
+                            style={{ backgroundColor: "#21262d", color: "#7d8590" }}
+                          >
+                            desde {assoc.since}
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </section>
+          )}
+
           {/* ── Fuentes ────────────────────────────────────────────────────── */}
           {judge.sourceLinks && judge.sourceLinks.length > 0 && (
             <section className="bg-ink-elevated border-border mb-6 overflow-hidden rounded-xl border">

--- a/app/juez/[slug]/page.tsx
+++ b/app/juez/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
   fetchJudgeBySlug,
   fetchJudgeCausasRanking,
   Judge,
+  POLITICAL_ORIGIN_CONFIG,
   ResultadoCaso,
 } from "../../lib/api";
 import { Tag, type TagVariant } from "../../components/Tag";
@@ -344,13 +345,7 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ slug: st
               {judge.appointmentDetail &&
                 (() => {
                   const d = judge.appointmentDetail;
-                  const originConfig: Record<string, { label: string; color: string }> = {
-                    judicial: { label: "Carrera judicial pura", color: "#3fb950" },
-                    academic: { label: "Origen académico", color: "#74ACDF" },
-                    mixed: { label: "Trayectoria mixta", color: "#F4B942" },
-                    political: { label: "Designación política", color: "#f85149" },
-                  };
-                  const cfg = originConfig[d.politicalOrigin];
+                  const cfg = POLITICAL_ORIGIN_CONFIG[d.politicalOrigin];
                   return (
                     <div className="px-5 py-4" style={{ borderBottom: "1px solid #21262d" }}>
                       <p

--- a/app/juez/[slug]/page.tsx
+++ b/app/juez/[slug]/page.tsx
@@ -370,6 +370,31 @@ export default function JudgeDetailPage({ params }: { params: Promise<{ slug: st
                         </p>
                       )}
 
+                      {d.politicalOriginSources && d.politicalOriginSources.length > 0 && (
+                        <ul className="mt-2 space-y-1">
+                          {d.politicalOriginSources.map((src, i) => (
+                            <li
+                              key={i}
+                              className="flex items-start gap-1.5 text-xs"
+                              style={{ color: "#8b949e" }}
+                            >
+                              <span className="mt-0.5 shrink-0" style={{ color: "#3d444d" }}>
+                                •
+                              </span>
+                              <a
+                                href={src.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="underline decoration-dotted transition-colors hover:opacity-80"
+                                style={{ color: "#74ACDF" }}
+                              >
+                                {src.label}
+                              </a>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+
                       {/* Concurso Magistratura */}
                       {(d.magistraturaScore !== undefined || d.magistraturaRank !== undefined) && (
                         <div className="mt-4 flex flex-wrap gap-3">

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -51,6 +51,29 @@ export interface JudgeSourceLink {
   description: string;
 }
 
+// ── Expediente Reputacional — Fase 1 ─────────────────────────────────────────
+
+export interface JudgeAssociation {
+  name: string;
+  role?: string;
+  since?: number;
+  sourceUrl?: string;
+}
+
+export type PoliticalOrigin = "judicial" | "political" | "academic" | "mixed";
+
+export interface JudgeAppointmentDetail {
+  politicalOrigin: PoliticalOrigin;
+  politicalOriginDetail?: string;
+  magistraturaScore?: number;
+  magistraturaRank?: number;
+  magistraturaCompetitionId?: string;
+  magistraturaSourceUrl?: string;
+  senateBackers?: string[];
+  senateSession?: string;
+  senateRecordUrl?: string;
+}
+
 // ── Campos extendidos (opcionales) ────────────────────────────────────────────
 
 export interface JudgeEducation {
@@ -111,6 +134,9 @@ export interface Judge {
   careerHistory?: JudgeCareerEntry[];
   notableDecisions?: JudgeNotableDecision[];
   extendedStats?: JudgeExtendedStats;
+  // Expediente Reputacional — Fase 1
+  associations?: JudgeAssociation[];
+  appointmentDetail?: JudgeAppointmentDetail;
 }
 
 // ── Bandas salariales y antigüedad ────────────────────────────────────────────

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -72,6 +72,7 @@ export const POLITICAL_ORIGIN_CONFIG: Record<PoliticalOrigin, { label: string; c
 export interface JudgeAppointmentDetail {
   politicalOrigin: PoliticalOrigin;
   politicalOriginDetail?: string;
+  politicalOriginSources?: { label: string; url: string }[];
   magistraturaScore?: number;
   magistraturaRank?: number;
   magistraturaCompetitionId?: string;

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -62,6 +62,13 @@ export interface JudgeAssociation {
 
 export type PoliticalOrigin = "judicial" | "political" | "academic" | "mixed";
 
+export const POLITICAL_ORIGIN_CONFIG: Record<PoliticalOrigin, { label: string; color: string }> = {
+  judicial: { label: "Carrera judicial pura", color: "#3fb950" },
+  academic: { label: "Origen académico", color: "#74ACDF" },
+  mixed: { label: "Trayectoria mixta", color: "#F4B942" },
+  political: { label: "Designación política", color: "#f85149" },
+};
+
 export interface JudgeAppointmentDetail {
   politicalOrigin: PoliticalOrigin;
   politicalOriginDetail?: string;

--- a/app/lib/expediente-reputacional.test.ts
+++ b/app/lib/expediente-reputacional.test.ts
@@ -1,4 +1,4 @@
-import { POLITICAL_ORIGIN_CONFIG, type PoliticalOrigin } from "./api";
+import { POLITICAL_ORIGIN_CONFIG, type PoliticalOrigin, type JudgeAppointmentDetail } from "./api";
 
 /**
  * Tests del Expediente Reputacional — Fase 1
@@ -54,5 +54,39 @@ describe("POLITICAL_ORIGIN_CONFIG", () => {
     expect(POLITICAL_ORIGIN_CONFIG.political.label).toMatch(/pol[ií]tica/i);
     expect(POLITICAL_ORIGIN_CONFIG.academic.label).toMatch(/acad[eé]m/i);
     expect(POLITICAL_ORIGIN_CONFIG.mixed.label).toMatch(/mixta/i);
+  });
+});
+
+// ── JudgeAppointmentDetail — politicalOriginSources ──────────────────────────
+
+describe("JudgeAppointmentDetail.politicalOriginSources", () => {
+  it("acepta una lista de fuentes con label y url", () => {
+    const detail: JudgeAppointmentDetail = {
+      politicalOrigin: "judicial",
+      politicalOriginSources: [
+        { label: "Ingresó al PJ en 2001", url: "https://example.com/res-45-2001" },
+        { label: "Concurso N° 247", url: "https://example.com/concurso-247" },
+      ],
+    };
+    expect(detail.politicalOriginSources).toHaveLength(2);
+    detail.politicalOriginSources!.forEach((src) => {
+      expect(typeof src.label).toBe("string");
+      expect(typeof src.url).toBe("string");
+    });
+  });
+
+  it("es opcional — puede estar ausente sin romper la interfaz", () => {
+    const detail: JudgeAppointmentDetail = {
+      politicalOrigin: "political",
+    };
+    expect(detail.politicalOriginSources).toBeUndefined();
+  });
+
+  it("label y url no pueden ser strings vacíos en datos válidos", () => {
+    const sources = [{ label: "Resolución senatorial 2020", url: "https://example.com/decreto" }];
+    sources.forEach((src) => {
+      expect(src.label.length).toBeGreaterThan(0);
+      expect(src.url.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/app/lib/expediente-reputacional.test.ts
+++ b/app/lib/expediente-reputacional.test.ts
@@ -1,0 +1,58 @@
+import { POLITICAL_ORIGIN_CONFIG, type PoliticalOrigin } from "./api";
+
+/**
+ * Tests del Expediente Reputacional — Fase 1
+ * Cubre: POLITICAL_ORIGIN_CONFIG y los 4 valores de PoliticalOrigin.
+ */
+
+describe("POLITICAL_ORIGIN_CONFIG", () => {
+  const origenes: PoliticalOrigin[] = ["judicial", "political", "academic", "mixed"];
+
+  it("tiene una entrada para cada valor de PoliticalOrigin", () => {
+    origenes.forEach((origen) => {
+      expect(POLITICAL_ORIGIN_CONFIG[origen]).toBeDefined();
+    });
+  });
+
+  it("cada entrada tiene label y color no vacíos", () => {
+    origenes.forEach((origen) => {
+      const cfg = POLITICAL_ORIGIN_CONFIG[origen];
+      expect(typeof cfg.label).toBe("string");
+      expect(cfg.label.length).toBeGreaterThan(0);
+      expect(typeof cfg.color).toBe("string");
+      expect(cfg.color.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("los colores son hex válidos (#rrggbb)", () => {
+    const hexColor = /^#[0-9a-fA-F]{6}$/;
+    origenes.forEach((origen) => {
+      expect(POLITICAL_ORIGIN_CONFIG[origen].color).toMatch(hexColor);
+    });
+  });
+
+  it('"judicial" tiene color verde (positivo)', () => {
+    // Verde indica carrera judicial pura — el color más "neutro/positivo"
+    expect(POLITICAL_ORIGIN_CONFIG.judicial.color).toBe("#3fb950");
+  });
+
+  it('"political" tiene color rojo (alerta)', () => {
+    // Rojo indica designación con fuerte componente político
+    expect(POLITICAL_ORIGIN_CONFIG.political.color).toBe("#f85149");
+  });
+
+  it('"academic" tiene color azul', () => {
+    expect(POLITICAL_ORIGIN_CONFIG.academic.color).toBe("#74ACDF");
+  });
+
+  it('"mixed" tiene color amarillo (intermedio)', () => {
+    expect(POLITICAL_ORIGIN_CONFIG.mixed.color).toBe("#F4B942");
+  });
+
+  it("los labels describen correctamente cada origen", () => {
+    expect(POLITICAL_ORIGIN_CONFIG.judicial.label).toMatch(/judicial/i);
+    expect(POLITICAL_ORIGIN_CONFIG.political.label).toMatch(/pol[ií]tica/i);
+    expect(POLITICAL_ORIGIN_CONFIG.academic.label).toMatch(/acad[eé]m/i);
+    expect(POLITICAL_ORIGIN_CONFIG.mixed.label).toMatch(/mixta/i);
+  });
+});

--- a/docs/expediente-reputacional-fase1.md
+++ b/docs/expediente-reputacional-fase1.md
@@ -1,0 +1,64 @@
+# Expediente Reputacional — Fase 1 (Frontend)
+
+## Contexto
+
+Ver [`observatorio-justicia-argentina-backend/docs/expediente-reputacional-fase1.md`](../../observatorio-justicia-argentina-backend/docs/expediente-reputacional-fase1.md) para el diseño completo de la feature.
+
+## Cambios en el frontend
+
+### Nuevos tipos en `app/lib/api.ts`
+
+```typescript
+interface JudgeAssociation {
+  name: string;
+  role?: string;
+  since?: number;
+  sourceUrl?: string;
+}
+
+type PoliticalOrigin = "judicial" | "political" | "academic" | "mixed";
+
+interface JudgeAppointmentDetail {
+  politicalOrigin: PoliticalOrigin;
+  politicalOriginDetail?: string;
+  magistraturaScore?: number;
+  magistraturaRank?: number;
+  magistraturaCompetitionId?: string;
+  magistraturaSourceUrl?: string;
+  senateBackers?: string[];
+  senateSession?: string;
+  senateRecordUrl?: string;
+}
+
+// Agregados a Judge:
+associations?: JudgeAssociation[];
+appointmentDetail?: JudgeAppointmentDetail;
+```
+
+### Nueva sección en `app/juez/[slug]/page.tsx`
+
+Sección **"Expediente reputacional"** renderizada entre el perfil y las fuentes oficiales. Aparece solo si el juez tiene `appointmentDetail` o `associations`.
+
+#### Subsección: Origen de la designación
+
+Badge de color codificado por `politicalOrigin`:
+
+| Valor | Label | Color |
+|---|---|---|
+| `judicial` | Carrera judicial pura | Verde |
+| `academic` | Origen académico | Azul |
+| `mixed` | Trayectoria mixta | Amarillo |
+| `political` | Designación política | Rojo |
+
+Debajo: texto libre `politicalOriginDetail`, stats del concurso (puntaje + puesto en mérito + link al acta), y senadores que avalaron el pliego.
+
+#### Subsección: Vínculos institucionales
+
+Lista de asociaciones con nombre (linkeable), rol y año de adhesión.
+
+## Archivos modificados
+
+| Archivo | Cambio |
+|---|---|
+| `app/lib/api.ts` | Nuevos tipos + campos en `Judge` |
+| `app/juez/[slug]/page.tsx` | Sección "Expediente reputacional" |

--- a/docs/judge-detail-page.md
+++ b/docs/judge-detail-page.md
@@ -1,0 +1,155 @@
+# Página de Detalle del Juez
+
+## Ruta
+
+```
+/juez/[slug]
+```
+
+**Ejemplo:** `/juez/juan-carlos-perez-gomez-caba`
+
+---
+
+## Archivos
+
+| Archivo | Rol |
+|---|---|
+| `app/juez/[slug]/page.tsx` | Componente de página (client component) |
+| `app/juez/[slug]/layout.tsx` | Metadata SEO dinámica (server component) |
+
+---
+
+## Flujo de datos
+
+```
+URL /juez/[slug]
+  → layout.tsx llama fetchJudgeBySlug(slug) → genera <title> y OG tags
+  → page.tsx llama fetchJudgeBySlug(slug)   → renderiza perfil
+  → page.tsx llama fetchJudgeCases(slug)    → tabla de casos paginada
+  → page.tsx llama fetchJudgeArchivos(slug) → listado de archivos
+```
+
+Los tres endpoints usan el slug semántico — ningún ID numérico aparece en las llamadas del frontend.
+
+---
+
+## SEO — `layout.tsx`
+
+Server component que implementa `generateMetadata()` de Next.js App Router.
+
+```typescript
+export async function generateMetadata({ params }): Promise<Metadata> {
+  const judge = await fetchJudgeBySlug(slug);
+  return {
+    title: `${judge.name} | Observatorio de Justicia Argentina`,
+    description: `${judge.name} — ${judge.court} (${judge.location.province}). Tasa de fracasos: ${failureRate}%...`,
+    openGraph: { title, description, url: `/juez/${slug}`, type: "profile" },
+    twitter: { card: "summary", title, description },
+    alternates: { canonical: `/juez/${slug}` },
+  };
+}
+```
+
+**¿Por qué layout y no page?** La `page.tsx` usa `"use client"` para manejar estado (carga, paginación). `generateMetadata` solo puede exportarse desde server components. El `layout.tsx` actúa como wrapper server que inyecta la metadata antes de renderizar el client component.
+
+---
+
+## Secciones del perfil
+
+### 1. Header
+- Nombre, badge FICTICIO si aplica
+- Tribunal, fuero, instancia, alcance/competencia
+- Provincia
+
+### 2. Métricas principales
+Cuatro `StatBox` con: libertades otorgadas, no comparecencias (FTA), nuevos arrestos, revocadas.
+
+Badge de tasa de falla procesal codificado por color:
+- `> 20%` → rojo
+- `10–20%` → amarillo
+- `< 10%` → verde
+
+### 3. Datos del cargo
+Grid con: domicilio laboral, horario, remuneración bruta (Acordada + categoría), fecha de designación, organismo designante, antigüedad.
+
+### 4. Bio pública
+Texto libre `publicBio`. Se muestra solo si el campo existe.
+
+### 5. Estadísticas extendidas *(opcional)*
+Grid con: días promedio de resolución, causas pendientes, recusaciones, resoluciones apeladas, revocadas en Cámara, tasa de revocación.
+
+### 6. Formación y trayectoria *(opcional)*
+- `education[]` — lista de títulos con año e institución
+- `careerHistory[]` — línea de tiempo de roles anteriores
+- `notableDecisions[]` — resoluciones destacadas con descripción y resultado
+
+### 7. Expediente Reputacional *(opcional — Fase 1)*
+Ver [`expediente-reputacional-fase1.md`](./expediente-reputacional-fase1.md).
+
+### 8. Tabla de casos
+Paginada con `limit = 10`. Cada fila muestra:
+- Nro. de expediente + fecha de resolución
+- Tipo de medida
+- Badge de resultado (`fta` / `nuevo_arresto` / `revocada` / `pendiente`)
+- Observaciones (si existen)
+
+Controles de paginación: anterior / siguiente + indicador `Página X de Y`.
+
+### 9. Archivos públicos
+Links a documentos asociados al juez (resoluciones, actas, etc.).
+
+### 10. Fuentes oficiales
+Links a portales institucionales de referencia (PJN, Consejo de la Magistratura, OA, SAIJ, etc.).
+
+---
+
+## Fallback a datos mock
+
+Si `fetchJudgeCases` o `fetchJudgeArchivos` fallan (backend no disponible), la página muestra datos de ejemplo predefinidos en `page.tsx` y un aviso amarillo al pie:
+
+> ⚠ Los casos y archivos mostrados son datos de ejemplo. El backend no está disponible en este momento.
+
+El perfil del juez (`fetchJudgeBySlug`) no tiene fallback: si falla, muestra error y no renderiza el perfil.
+
+---
+
+## Funciones de API
+
+```typescript
+// app/lib/api.ts
+
+fetchJudgeBySlug(slug: string): Promise<Judge>
+// GET /judges/:slug
+
+fetchJudgeCases(slug: string, page?: number, limit?: number): Promise<PaginatedResult<Caso>>
+// GET /judges/:slug/casos?page=1&limit=10
+
+fetchJudgeArchivos(slug: string): Promise<ArchivoPublico[]>
+// GET /judges/:slug/archivos
+```
+
+---
+
+## Migración de `[id]` a `[slug]`
+
+La ruta original era `/juez/[id]` con ID numérico. Se migró a `/juez/[slug]` por:
+
+1. **SEO**: Google indexa el nombre del juez directamente en la URL
+2. **Compartibilidad**: `/juez/juan-carlos-perez-gomez-caba` es autoexplicativo en redes y medios
+3. **Seguridad**: elimina la enumeración de perfiles por ID numérico secuencial
+4. **Estabilidad**: el slug basado en nombre+provincia es estable ante migraciones de base de datos
+
+---
+
+## JudgeCard (home)
+
+El componente `app/components/JudgeCard.tsx` muestra el resumen del juez en la home y linkea al perfil completo.
+
+Se eliminó el panel acordeón ("Ver detalle completo") que duplicaba información ya disponible en esta página. El card ahora es un elemento limpio y completamente clickeable que navega al perfil.
+
+Datos mostrados en el card:
+- Nombre, tribunal, provincia
+- Jurisdicción (fuero, instancia, alcance/competencia)
+- Métricas: libertades, FTA, nuevo arresto, revocada
+- Tasa de falla procesal (badge color)
+- Escala salarial (badge color)

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^20",


### PR DESCRIPTION
⚠️ Orden de merge requerido: este PR debe mergearse después de feat/causas. Incluye el mismo setup de Jest; si causas ya está en develop, hacer rebase antes de mergear.


## Resumen

Agrega la sección **Expediente Reputacional** en la vista de detalle del juez (`/juez/[slug]`), mostrando origen político de la designación y vínculos institucionales.

> PR de backend relacionado: `feat(expediente-reputacional): Fase 1 — trayectoria política y vínculos institucionales`

## Cambios

### `app/lib/api.ts`

- Nuevas interfaces: `JudgeAssociation`, `JudgeAppointmentDetail`, `PoliticalOrigin`
- **`POLITICAL_ORIGIN_CONFIG`** exportado — mapa de colores y labels por valor de `PoliticalOrigin`:
  - `judicial` → verde `#3fb950`
  - `academic` → azul `#74ACDF`
  - `mixed` → amarillo `#F4B942`
  - `political` → rojo `#f85149`
- `politicalOriginSources?: { label: string; url: string }[]` en `JudgeAppointmentDetail`

### `app/juez/[slug]/page.tsx`

- Nueva sección colapsable "Expediente Reputacional" con:
  - Badge de `politicalOrigin` con color semántico
  - Lista de `associations` (nombre, rol, año, link a fuente)
  - Lista de `politicalOriginSources` — links con subrayado punteado en azul
  - Datos de la Magistratura (puntaje, puesto, concurso)
  - Senadores que avalaron el pliego + link a sesión taquigráfica

### Tests — 11 passing (`expediente-reputacional.test.ts`)

Cubren `POLITICAL_ORIGIN_CONFIG` (colores, labels, hex válidos) y `politicalOriginSources` (tipado, opcionalidad).

## Test plan

- [ ] `npm test -- expediente-reputacional` → 11 tests passing
- [ ] `/juez/juan-carlos-perez-gomez-caba` → badge verde "Carrera judicial pura" + lista de 3 fuentes
- [ ] `/juez/maria-elena-gutierrez-sosa-buenos-aires` → badge amarillo "Trayectoria mixta" + 2 asociaciones
- [ ] `/juez/roberto-ernesto-molina-paz-cordoba` → badge rojo "Designación política"
- [ ] Jueces sin datos: la sección no se renderiza